### PR TITLE
Fix sort multivalue tags plugin

### DIFF
--- a/contrib/plugins/sort_multivalue_tags.py
+++ b/contrib/plugins/sort_multivalue_tags.py
@@ -36,10 +36,9 @@ _sort_multivalue_tags_exclude = [
     ]
 
 def sort_multivalue_tags(album, metadata, *args):
-    for tag in metadata.keys():
+    for tag, data in metadata.iteritems():
         if tag in _sort_multivalue_tags_exclude:
             continue
-        data = dict.get(metadata, tag)
         if len(data) > 1:
             sorted_data = sorted(data)
             if data != sorted_data:

--- a/contrib/plugins/sort_multivalue_tags.py
+++ b/contrib/plugins/sort_multivalue_tags.py
@@ -39,6 +39,6 @@ def sort_multivalue_tags(album, metadata, *args):
         if len(data) > 1:
             sorted_data = sorted(data)
             if data != sorted_data:
-                metadata.set(tag,sorted_data)
+                metadata.set(tag, sorted_data)
 
 register_track_metadata_processor(sort_multivalue_tags)

--- a/contrib/plugins/sort_multivalue_tags.py
+++ b/contrib/plugins/sort_multivalue_tags.py
@@ -15,7 +15,11 @@
 
 PLUGIN_NAME = u"Sort Multi-Value Tags"
 PLUGIN_AUTHOR = u"Sophist"
-PLUGIN_DESCRIPTION = u'Sort Multi-Value Tags e.g. Performers alphabetically.'
+PLUGIN_DESCRIPTION = u'''Sort Multi-Value Tags e.g. Performers alphabetically.
+<br/>
+Note: For some multi-value tags the position has meaning
+(e.g. for artists, the first item is the primary track artist)
+and these tags are NOT sorted.'''
 PLUGIN_VERSION = "0.3"
 PLUGIN_API_VERSIONS = ["0.15.0", "0.15.1", "0.16.0", "1.0.0", "1.1.0", "1.2.0", "1.3.0"]
 
@@ -24,7 +28,7 @@ from picard.metadata import register_track_metadata_processor
 # Exclude the following tags because the sort order is related to other tags or has a meaning like primary artist
 _sort_multivalue_tags_exclude = [
     'artists', '~artists_sort', 'musicbrainz_artistid',
-    'albumartist', '~albumartists_sort', 'musicbrainz_albumartistid',
+    'albumartists', '~albumartists_sort', 'musicbrainz_albumartistid',
     'work', 'musicbrainz_workid',
     'label', 'catalognumber',
     'country', 'date',

--- a/contrib/plugins/sort_multivalue_tags.py
+++ b/contrib/plugins/sort_multivalue_tags.py
@@ -16,30 +16,29 @@
 PLUGIN_NAME = u"Sort Multi-Value Tags"
 PLUGIN_AUTHOR = u"Sophist"
 PLUGIN_DESCRIPTION = u'Sort Multi-Value Tags e.g. Performers alphabetically.'
-PLUGIN_VERSION = "0.2"
+PLUGIN_VERSION = "0.3"
 PLUGIN_API_VERSIONS = ["0.15.0", "0.15.1", "0.16.0", "1.0.0", "1.1.0", "1.2.0", "1.3.0"]
 
 from picard.metadata import register_track_metadata_processor
 
-class SortMultiValueTags:
+# Exclude the following tags because the sort order is related to other tags or has a meaning like primary artist
+_sort_multivalue_tags_exclude = [
+    'artists', '~artists_sort', 'musicbrainz_artistid',
+    'albumartist', '~albumartists_sort', 'musicbrainz_albumartistid',
+    'work', 'musicbrainz_workid',
+    'label', 'catalognumber',
+    'country', 'date',
+    'releasetype',
+    ]
 
-    # Exclude the following tags because the sort order is related to other tags or has a meaning like primary artist
-    exclude_tags = [
-        'artist', 'artistsort', 'musicbrainz_artistid',
-        'albumartist', 'albumartistsort', 'musicbrainz_albumartistid',
-        'releasetype',
-        ]
+def sort_multivalue_tags(album, metadata, *args):
+    for tag in metadata.keys():
+        if tag in _sort_multivalue_tags_exclude:
+            continue
+        data = dict.get(metadata, tag)
+        if len(data) > 1:
+            sorted_data = sorted(data)
+            if data != sorted_data:
+                metadata.set(tag,sorted_data)
 
-    # Define and register the Track Metadata function
-    def sort_multivalue_tags(self, tagger, metadata, track, release):
-
-        for tag in metadata.keys():
-            if tag in SortMultiValueTags.exclude_tags:
-                continue
-            data = dict.get(metadata, tag)
-            if len(data) > 1:
-                sorted_data = sorted(data)
-                if data != sorted_data:
-                    metadata.set(tag,sorted_data)
-
-register_track_metadata_processor(SortMultiValueTags().sort_multivalue_tags)
+register_track_metadata_processor(sort_multivalue_tags)

--- a/contrib/plugins/sort_multivalue_tags.py
+++ b/contrib/plugins/sort_multivalue_tags.py
@@ -15,22 +15,31 @@
 
 PLUGIN_NAME = u"Sort Multi-Value Tags"
 PLUGIN_AUTHOR = u"Sophist"
-PLUGIN_DESCRIPTION = u'Sort Multi-Value Tags e.g. Release Type, Lyrics alphabetically.'
-PLUGIN_VERSION = "0.1"
-PLUGIN_API_VERSIONS = ["0.15"]
+PLUGIN_DESCRIPTION = u'Sort Multi-Value Tags e.g. Performers alphabetically.'
+PLUGIN_VERSION = "0.2"
+PLUGIN_API_VERSIONS = ["0.15.0", "0.15.1", "0.16.0", "1.0.0", "1.1.0", "1.2.0", "1.3.0"]
 
 from picard.metadata import register_track_metadata_processor
 
-# Define and register the Track Metadata function
+class SortMultiValueTags:
 
+    # Exclude the following tags because the sort order is related to other tags or has a meaning like primary artist
+    exclude_tags = [
+        'artist', 'artistsort', 'musicbrainz_artistid',
+        'albumartist', 'albumartistsort', 'musicbrainz_albumartistid',
+        'releasetype',
+        ]
 
-def sort_multivalue_tags(tagger, metadata, track, release):
+    # Define and register the Track Metadata function
+    def sort_multivalue_tags(self, tagger, metadata, track, release):
 
-    for tag in metadata.keys():
-        data = metadata.getall(tag)
-        if len(data) > 1:
-            sorted_data = sorted(data)
-            if data != sorted_data:
-                metadata.set(tag, sorted_data)
+        for tag in metadata.keys():
+            if tag in SortMultiValueTags.exclude_tags:
+                continue
+            data = dict.get(metadata, tag)
+            if len(data) > 1:
+                sorted_data = sorted(data)
+                if data != sorted_data:
+                    metadata.set(tag,sorted_data)
 
-register_track_metadata_processor(sort_multivalue_tags)
+register_track_metadata_processor(SortMultiValueTags().sort_multivalue_tags)


### PR DESCRIPTION
Exclude certain multi-value tags from sorting because the order is important.