### PR TITLE
Support for multiple configuration profiles

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -93,20 +93,10 @@ class Config(QtCore.QSettings):
         self.application = ConfigSection(self, "application")
         self.setting = ConfigSection(self, "setting")
         self.persist = ConfigSection(self, "persist")
-        self.profile = ConfigSection(self, "profile/default")
-        self.current_preset = "default"
 
         TextOption("application", "version", '0.0.0dev0')
         self._version = version_from_string(self.application["version"])
         self._upgrade_hooks = dict()
-
-    def switchProfile(self, profilename):
-        """Sets the current profile."""
-        key = u"profile/%s" % (profilename,)
-        if self.contains(key):
-            self.profile.name = key
-        else:
-            raise KeyError("Unknown profile '%s'" % (profilename,))
 
     def register_upgrade_hook(self, func, *args):
         """Register a function to upgrade from one config version to another"""

--- a/picard/config.py
+++ b/picard/config.py
@@ -39,13 +39,12 @@ class ConfigSection(LockableObject):
         self.__name = name
 
     def __getitem__(self, name):
-        key = "%s/%s" % (self.__name, name)
         opt = Option.get(self.__name, name)
         if opt is None:
             return None
         self.lock_for_read()
         try:
-            if self.__config.contains(key):
+            if self.__config.contains(self._key(name)):
                 return opt.convert(self.raw_value(name))
             return opt.default
         except:
@@ -56,22 +55,21 @@ class ConfigSection(LockableObject):
     def __setitem__(self, name, value):
         self.lock_for_write()
         try:
-            self.__config.setValue("%s/%s" % (self.__name, name), value)
+            self.__config.setValue(self._key(name), value)
         finally:
             self.unlock()
 
     def __contains__(self, key):
-        key = "%s/%s" % (self.__name, key)
-        return self.__config.contains(key)
+        return self.__config.contains(self._key(key))
 
     def remove(self, key):
-        key = "%s/%s" % (self.__name, key)
+        key = self._key(key)
         if self.__config.contains(key):
             self.__config.remove(key)
 
     def raw_value(self, key):
         """Return an option value without any type conversion."""
-        value = self.__config.value("%s/%s" % (self.__name, key))
+        value = self.__config.value(self._key(key))
 
         # XXX QPyNullVariant does not exist in all PyQt versions, and was
         # removed entirely in PyQt5. See:
@@ -80,6 +78,9 @@ class ConfigSection(LockableObject):
             return ""
 
         return value
+
+    def _key(self, key):
+        return "%s/%s" % (self.__name, key)
 
 
 class Config(QtCore.QSettings):

--- a/picard/config.py
+++ b/picard/config.py
@@ -39,7 +39,7 @@ class ConfigSection(LockableObject):
         self.__name = name
 
     def __getitem__(self, name):
-        opt = Option.get(self.__name, name)
+        opt = Option.get(self._name(), name)
         if opt is None:
             return None
         self.lock_for_read()
@@ -80,7 +80,10 @@ class ConfigSection(LockableObject):
         return value
 
     def _key(self, key):
-        return "%s/%s" % (self.__name, key)
+        return "%s/%s" % (self._name(), key)
+
+    def _name(self):
+        return self.__name
 
 
 class Config(QtCore.QSettings):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -94,7 +94,7 @@ class Tagger(QtGui.QApplication):
 
     __instance = None
 
-    def __init__(self, args, localedir, autoupdate, debug=False):
+    def __init__(self, args, localedir, autoupdate, debug=False, profile=None):
         QtGui.QApplication.__init__(self, args)
         self.__class__.__instance = self
 
@@ -158,6 +158,11 @@ class Tagger(QtGui.QApplication):
         QtCore.QObject.config = config
         QtCore.QObject.log = log
 
+        config.use_profile(profile)
+        if config.profile() is None:
+            log.debug("Using default configuration profile")
+        else:
+            log.debug("Using '%s' configuration profile" % config.profile())
         check_io_encoding()
 
         # Must be before config upgrade because upgrade dialogs need to be
@@ -642,6 +647,7 @@ from the filenames.
 Options:
     -d, --debug             enable debug-level logging
     -h, --help              display this help and exit
+    -p, --profile           use this configuration profile, create one if needed
     -v, --version           display version information and exit
 """ % (sys.argv[0],)
 
@@ -656,7 +662,8 @@ def main(localedir=None, autoupdate=True):
     QtGui.QApplication.setOrganizationName(PICARD_ORG_NAME)
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)
-    opts, args = getopt.gnu_getopt(sys.argv[1:], "hvd", ["help", "version", "debug"])
+    opts, args = getopt.gnu_getopt(sys.argv[1:], "hvdp:", ["help", "version",
+                                                           "debug", "profile="])
     kwargs = {}
     for opt, arg in opts:
         if opt in ("-h", "--help"):
@@ -665,6 +672,8 @@ def main(localedir=None, autoupdate=True):
             return version()
         elif opt in ("-d", "--debug"):
             kwargs["debug"] = True
+        elif opt in ("-p", "--profile"):
+            kwargs["profile"] = arg.decode(sys.stdin.encoding)
     tagger = Tagger(args, localedir, autoupdate, **kwargs)
     tagger.startTimer(1000)
     sys.exit(tagger.run())

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -86,6 +86,9 @@ class OptionsDialog(PicardDialog):
         self.ui.buttonbox.rejected.connect(self.reject)
         self.ui.buttonbox.helpRequested.connect(self.help)
 
+        if config.profile() is not None:
+            self.setWindowTitle(_(u'Options [%s]') % config.profile())
+
         self.pages = []
         for Page in page_classes:
             page = Page(self.ui.pages_stack)


### PR DESCRIPTION
To use a new profile:
```bash
$> python tagger.py -p profile1
```
On first run, profile will be created.
On next runs, already existing profile of the same name will be reused.

