### PR TITLE
PICARD-683: For MP4 files add the codec description to ~format.

### DIFF
--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -216,3 +216,8 @@ class MP4File(File):
             or name in self.__r_freeform_tags\
             or name in self.__other_supported_tags\
             or name.startswith('lyrics:')
+
+    def _info(self, metadata, file):
+        super(MP4File, self)._info(metadata, file)
+        if hasattr(file.info, 'codec_description') and file.info.codec_description:
+            metadata['~format'] = "%s (%s)" % (metadata['~format'], file.info.codec_description)


### PR DESCRIPTION
Requires mutagen 1.27, but is backwards compatible with older versions.

Fixes [PICARD-683](http://tickets.musicbrainz.org/browse/PICARD-683)