### PR TITLE
Deduplicate work names in tags.

### DIFF
--- a/picard/mbxml.py
+++ b/picard/mbxml.py
@@ -299,7 +299,7 @@ def work_to_metadata(work, m):
     if 'language' in work.children:
         m.add_unique("language", work.language[0].text)
     if 'title' in work.children:
-        m.add("work", work.title[0].text)
+        m.add_unique("work", work.title[0].text)
     if 'relation_list' in work.children:
         _relations_to_metadata(work.relation_list, m)
 


### PR DESCRIPTION
Fixes [PICARD-375](http://tickets.musicbrainz.org/browse/PICARD-375)

The ticket was already partially fixed as https://github.com/musicbrainz/picard/commit/008bee3e2e0f0ec2aa5d7e1aa51e12c3bc02d9eb does de-duplicate all MBID lists. But for this ticket to be completely solved I think also the work list should be de-duplicated.