### PR TITLE
[PICARD-695] Tags are not properly cleared for some files even with the clear metadata option.

### DIFF
--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -119,7 +119,7 @@ class APEv2File(File):
             tags = mutagen.apev2.APEv2()
         if config.setting["clear_existing_tags"]:
             if config.setting["remove_extra_padding"]:
-                tags.delete()
+                tags.delete(filename)
             else:
                 tags.clear()
         elif metadata.images_to_be_saved_to_tags:

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -118,7 +118,10 @@ class APEv2File(File):
         except mutagen.apev2.APENoHeaderError:
             tags = mutagen.apev2.APEv2()
         if config.setting["clear_existing_tags"]:
-            tags.clear()
+            if config.setting["remove_extra_padding"]:
+                tags.delete()
+            else:
+                tags.clear()
         elif metadata.images_to_be_saved_to_tags:
             for name, value in tags.items():
                 if name.lower().startswith('cover art') and value.kind == mutagen.apev2.BINARY:

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -186,8 +186,11 @@ class ASFFile(File):
         log.debug("Saving file %r", filename)
         file = ASF(encode_filename(filename))
 
-        if config.setting['clear_existing_tags']:
-            file.tags.clear()
+        if config.setting["clear_existing_tags"]:
+            if config.setting["remove_extra_padding"]:
+                file.delete()
+            else:
+                file.tags.clear()
         cover = []
         for image in metadata.images_to_be_saved_to_tags:
             tag_data = pack_image(image.mimetype, image.data,

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -188,7 +188,10 @@ class ASFFile(File):
 
         if config.setting["clear_existing_tags"]:
             if config.setting["remove_extra_padding"]:
-                file.delete()
+                try:
+                    file.delete()
+                except NotImplementedError:
+                    file.tags.clear()
             else:
                 file.tags.clear()
         cover = []

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -298,7 +298,7 @@ class ID3File(File):
 
         if config.setting["clear_existing_tags"]:
             if config.setting["remove_extra_padding"]:
-                tags.delete()
+                tags.delete(filename)
             else:
                 tags.clear()
         if metadata.images_to_be_saved_to_tags:

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -296,8 +296,11 @@ class ID3File(File):
         log.debug("Saving file %r", filename)
         tags = self._get_tags(filename)
 
-        if config.setting['clear_existing_tags']:
-            tags.clear()
+        if config.setting["clear_existing_tags"]:
+            if config.setting["remove_extra_padding"]:
+                tags.delete()
+            else:
+                tags.clear()
         if metadata.images_to_be_saved_to_tags:
             tags.delall('APIC')
 

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -166,7 +166,10 @@ class MP4File(File):
             file.add_tags()
 
         if config.setting["clear_existing_tags"]:
-            file.tags.clear()
+            if config.setting["remove_extra_padding"]:
+                file.delete()
+            else:
+                file.tags.clear()
 
         for name, values in metadata.rawitems():
             if name.startswith('lyrics:'):

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -160,6 +160,8 @@ class VCommentFile(File):
         if config.setting["clear_existing_tags"]:
             if config.setting["remove_extra_padding"]:
                 file.delete()
+                if file.tags is None:
+                    file.add_tags()
             else:
                 file.tags.clear()
         if (is_flac and (config.setting["clear_existing_tags"] or

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -158,7 +158,10 @@ class VCommentFile(File):
         if file.tags is None:
             file.add_tags()
         if config.setting["clear_existing_tags"]:
-            file.tags.clear()
+            if config.setting["remove_extra_padding"]:
+                file.delete()
+            else:
+                file.tags.clear()
         if (is_flac and (config.setting["clear_existing_tags"] or
                          metadata.images_to_be_saved_to_tags)):
             file.clear_pictures()

--- a/picard/ui/options/tags.py
+++ b/picard/ui/options/tags.py
@@ -34,6 +34,7 @@ class TagsOptionsPage(OptionsPage):
 
     options = [
         config.BoolOption("setting", "clear_existing_tags", False),
+        config.BoolOption("setting", "remove_extra_padding", False),
         config.TextOption("setting", "preserved_tags", ""),
         config.BoolOption("setting", "write_id3v1", True),
         config.BoolOption("setting", "write_id3v23", True),
@@ -50,6 +51,8 @@ class TagsOptionsPage(OptionsPage):
         super(TagsOptionsPage, self).__init__(parent)
         self.ui = Ui_TagsOptionsPage()
         self.ui.setupUi(self)
+        self.ui.clear_existing_tags.toggled.connect(self.ui.remove_extra_padding.setEnabled)
+        self.ui.clear_existing_tags.toggled.connect(lambda x : self.ui.remove_extra_padding.setChecked(False))
         self.ui.write_id3v23.clicked.connect(self.update_encodings)
         self.ui.write_id3v24.clicked.connect(self.update_encodings)
         self.completer = QtGui.QCompleter(sorted(TAG_NAMES.keys()), self)
@@ -62,6 +65,11 @@ class TagsOptionsPage(OptionsPage):
         self.ui.write_tags.setChecked(not config.setting["dont_write_tags"])
         self.ui.preserve_timestamps.setChecked(config.setting["preserve_timestamps"])
         self.ui.clear_existing_tags.setChecked(config.setting["clear_existing_tags"])
+        if not config.setting["clear_existing_tags"]:
+            self.ui.remove_extra_padding.setEnabled(False)
+            self.ui.remove_extra_padding.setChecked(False)
+        else:
+            self.ui.remove_extra_padding.setChecked(config.setting["remove_extra_padding"])
         self.ui.write_id3v1.setChecked(config.setting["write_id3v1"])
         self.ui.write_id3v23.setChecked(config.setting["write_id3v23"])
         if config.setting["id3v2_encoding"] == "iso-8859-1":
@@ -83,6 +91,7 @@ class TagsOptionsPage(OptionsPage):
         if clear_existing_tags != config.setting["clear_existing_tags"]:
             config.setting["clear_existing_tags"] = clear_existing_tags
             self.tagger.window.metadata_box.update()
+        config.setting["remove_extra_padding"] = self.ui.clear_existing_tags.isChecked() and self.ui.remove_extra_padding.isChecked()
         config.setting["write_id3v1"] = self.ui.write_id3v1.isChecked()
         config.setting["write_id3v23"] = self.ui.write_id3v23.isChecked()
         config.setting["id3v23_join_with"] = unicode(self.ui.id3v23_join_with.currentText())

--- a/picard/ui/ui_options_tags.py
+++ b/picard/ui/ui_options_tags.py
@@ -8,7 +8,16 @@ from PyQt4 import QtCore, QtGui
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
 except AttributeError:
-    _fromUtf8 = lambda s: s
+    def _fromUtf8(s):
+        return s
+
+try:
+    _encoding = QtGui.QApplication.UnicodeUTF8
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig, _encoding)
+except AttributeError:
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig)
 
 class Ui_TagsOptionsPage(object):
     def setupUi(self, TagsOptionsPage):
@@ -28,9 +37,17 @@ class Ui_TagsOptionsPage(object):
         self.vboxlayout1.setSpacing(2)
         self.vboxlayout1.setContentsMargins(-1, 6, -1, 7)
         self.vboxlayout1.setObjectName(_fromUtf8("vboxlayout1"))
+        self.clear_or_delete = QtGui.QHBoxLayout()
+        self.clear_or_delete.setSpacing(0)
+        self.clear_or_delete.setContentsMargins(-1, 0, -1, -1)
+        self.clear_or_delete.setObjectName(_fromUtf8("clear_or_delete"))
         self.clear_existing_tags = QtGui.QCheckBox(self.before_tagging)
         self.clear_existing_tags.setObjectName(_fromUtf8("clear_existing_tags"))
-        self.vboxlayout1.addWidget(self.clear_existing_tags)
+        self.clear_or_delete.addWidget(self.clear_existing_tags)
+        self.remove_extra_padding = QtGui.QCheckBox(self.before_tagging)
+        self.remove_extra_padding.setObjectName(_fromUtf8("remove_extra_padding"))
+        self.clear_or_delete.addWidget(self.remove_extra_padding)
+        self.vboxlayout1.addLayout(self.clear_or_delete)
         self.remove_id3_from_flac = QtGui.QCheckBox(self.before_tagging)
         self.remove_id3_from_flac.setObjectName(_fromUtf8("remove_id3_from_flac"))
         self.vboxlayout1.addWidget(self.remove_id3_from_flac)
@@ -137,7 +154,8 @@ class Ui_TagsOptionsPage(object):
         QtCore.QMetaObject.connectSlotsByName(TagsOptionsPage)
         TagsOptionsPage.setTabOrder(self.write_tags, self.preserve_timestamps)
         TagsOptionsPage.setTabOrder(self.preserve_timestamps, self.clear_existing_tags)
-        TagsOptionsPage.setTabOrder(self.clear_existing_tags, self.remove_id3_from_flac)
+        TagsOptionsPage.setTabOrder(self.clear_existing_tags, self.remove_extra_padding)
+        TagsOptionsPage.setTabOrder(self.remove_extra_padding, self.remove_id3_from_flac)
         TagsOptionsPage.setTabOrder(self.remove_id3_from_flac, self.remove_ape_from_mp3)
         TagsOptionsPage.setTabOrder(self.remove_ape_from_mp3, self.preserved_tags)
         TagsOptionsPage.setTabOrder(self.preserved_tags, self.write_id3v24)
@@ -153,6 +171,7 @@ class Ui_TagsOptionsPage(object):
         self.preserve_timestamps.setText(_("Preserve timestamps of tagged files"))
         self.before_tagging.setTitle(_("Before Tagging"))
         self.clear_existing_tags.setText(_("Clear existing tags"))
+        self.remove_extra_padding.setText(_("Remove extra padding"))
         self.remove_id3_from_flac.setText(_("Remove ID3 tags from FLAC files"))
         self.remove_ape_from_mp3.setText(_("Remove APEv2 tags from MP3 files"))
         self.preserved_tags_label.setText(_("Preserve these tags from being cleared or overwritten with MusicBrainz data:"))

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -15,6 +15,7 @@ from tempfile import mkstemp
 settings = {
     'enabled_plugins': '',
     'clear_existing_tags': False,
+    'remove_extra_padding': False,
     'remove_images_from_tags': False,
     'write_id3v1': True,
     'id3v2_encoding': 'utf-8',

--- a/ui/options_tags.ui
+++ b/ui/options_tags.ui
@@ -41,11 +41,28 @@
        <number>7</number>
       </property>
       <item>
-       <widget class="QCheckBox" name="clear_existing_tags">
-        <property name="text">
-         <string>Clear existing tags</string>
+       <layout class="QHBoxLayout" name="clear_or_delete">
+        <property name="spacing">
+         <number>0</number>
         </property>
-       </widget>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="clear_existing_tags">
+          <property name="text">
+           <string>Clear existing tags</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="remove_extra_padding">
+          <property name="text">
+           <string>Remove extra padding</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
        <widget class="QCheckBox" name="remove_id3_from_flac">
@@ -312,6 +329,7 @@
   <tabstop>write_tags</tabstop>
   <tabstop>preserve_timestamps</tabstop>
   <tabstop>clear_existing_tags</tabstop>
+  <tabstop>remove_extra_padding</tabstop>
   <tabstop>remove_id3_from_flac</tabstop>
   <tabstop>remove_ape_from_mp3</tabstop>
   <tabstop>preserved_tags</tabstop>


### PR DESCRIPTION
Hello, I notice that in some case, the metadata were not competetly cleared even with the option enabled.
By saving the file without any metadata before saving with the metadata, it seems to work. I would like to provide the mp3 to illustrate the problem but the file is too big...

Thank you for your work, it is great ;)