### PR TITLE
PICARD-707: Validate the fpcalc executable in options.

### DIFF
--- a/picard/ui/ui_options_fingerprinting.py
+++ b/picard/ui/ui_options_fingerprinting.py
@@ -8,7 +8,16 @@ from PyQt4 import QtCore, QtGui
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
 except AttributeError:
-    _fromUtf8 = lambda s: s
+    def _fromUtf8(s):
+        return s
+
+try:
+    _encoding = QtGui.QApplication.UnicodeUTF8
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig, _encoding)
+except AttributeError:
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig)
 
 class Ui_FingerprintingOptionsPage(object):
     def setupUi(self, FingerprintingOptionsPage):
@@ -47,6 +56,10 @@ class Ui_FingerprintingOptionsPage(object):
         self.acoustid_fpcalc_download.setObjectName(_fromUtf8("acoustid_fpcalc_download"))
         self.horizontalLayout_2.addWidget(self.acoustid_fpcalc_download)
         self.verticalLayout_2.addLayout(self.horizontalLayout_2)
+        self.acoustid_fpcalc_info = QtGui.QLabel(self.acoustid_settings)
+        self.acoustid_fpcalc_info.setText(_fromUtf8(""))
+        self.acoustid_fpcalc_info.setObjectName(_fromUtf8("acoustid_fpcalc_info"))
+        self.verticalLayout_2.addWidget(self.acoustid_fpcalc_info)
         self.label_2 = QtGui.QLabel(self.acoustid_settings)
         self.label_2.setObjectName(_fromUtf8("label_2"))
         self.verticalLayout_2.addWidget(self.label_2)

--- a/ui/options_fingerprinting.ui
+++ b/ui/options_fingerprinting.ui
@@ -72,6 +72,13 @@
        </layout>
       </item>
       <item>
+       <widget class="QLabel" name="acoustid_fpcalc_info">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="label_2">
         <property name="text">
          <string>API key:</string>


### PR DESCRIPTION
This patch validates the selected fpcalc executable in the options, if fingerprinting is enabled. The validation is done by running `fpcalc -v` and checking the output.

Fixes [PICARD-707](http://tickets.musicbrainz.org/browse/PICARD-707)