### PR TITLE
Add an context menu entry to select all items in a treeview.

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -232,6 +232,9 @@ class BaseTreeView(QtGui.QTreeWidget):
         self.expand_all_action.triggered.connect(self.expandAll)
         self.collapse_all_action = QtGui.QAction(_("&Collapse all"), self)
         self.collapse_all_action.triggered.connect(self.collapseAll)
+        self.select_all_action = QtGui.QAction(_("Select &all"), self)
+        self.select_all_action.triggered.connect(self.selectAll)
+        self.select_all_action.setShortcut(QtGui.QKeySequence(_(u"Ctrl+A")))
         self.doubleClicked.connect(self.activate_item)
 
     def contextMenuEvent(self, event):
@@ -383,6 +386,7 @@ class BaseTreeView(QtGui.QTreeWidget):
             menu.addAction(self.expand_all_action)
             menu.addAction(self.collapse_all_action)
 
+        menu.addAction(self.select_all_action)
         menu.exec_(event.globalPos())
         event.accept()
 


### PR DESCRIPTION
Some people don't know about the CTRL-A shortcut or shift click action to select all items in one of the treeview panes. This commit adds a discoverable context menu entry for those people. Typical use cases are selecting all items to then remove or save all items at once.

Fixes [PICARD-476](http://tickets.musicbrainz.org/browse/PICARD-476) and probably even [PICARD-210](http://tickets.musicbrainz.org/browse/PICARD-210).

Do you think this is valuable without adding too much clutter? Would you agree to consider this a solution to [PICARD-210](http://tickets.musicbrainz.org/browse/PICARD-210), too?