### PR TITLE
Add a -V/--long-version command-line option, display Qt version

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -662,11 +662,15 @@ Options:
     -d, --debug             enable debug-level logging
     -h, --help              display this help and exit
     -v, --version           display version information and exit
+    -V, --long-version      display long version information and exit
 """ % (sys.argv[0],)
 
 
 def version():
     print "%s %s %s" % (PICARD_ORG_NAME, PICARD_APP_NAME, PICARD_FANCY_VERSION_STR)
+
+def longversion():
+    print versions.as_string()
 
 
 def main(localedir=None, autoupdate=True):
@@ -675,13 +679,16 @@ def main(localedir=None, autoupdate=True):
     QtGui.QApplication.setOrganizationName(PICARD_ORG_NAME)
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)
-    opts, args = getopt.gnu_getopt(sys.argv[1:], "hvd", ["help", "version", "debug"])
+    opts, args = getopt.gnu_getopt(sys.argv[1:], "hvdV", ["help", "version",
+                                                          "debug", "long-version"])
     kwargs = {}
     for opt, arg in opts:
         if opt in ("-h", "--help"):
             return help()
         elif opt in ("-v", "--version"):
             return version()
+        elif opt in ("-V", "--long-version"):
+            return longversion()
         elif opt in ("-d", "--debug"):
             kwargs["debug"] = True
     tagger = Tagger(args, localedir, autoupdate, **kwargs)

--- a/picard/ui/options/about.py
+++ b/picard/ui/options/about.py
@@ -57,20 +57,22 @@ class AboutOptionsPage(OptionsPage):
         else:
             args["translator-credits"] = ""
 
+        args['third_parties_versions'] = '<br />'.join([u"%s %s" %
+                                                        (versions.version_name(name), value) for name, value
+                                                        in versions.as_dict(i18n=True).items()
+                                                        if name != 'version'])
         text = _(u"""<p align="center"><span style="font-size:15px;font-weight:bold;">MusicBrainz Picard</span><br/>
 Version %(version)s</p>
 <p align="center"><small>
-PyQt %(pyqt-version)s<br/>
-Mutagen %(mutagen-version)s<br/>
-Discid %(discid-version)s
+%(third_parties_versions)s
 </small></p>
 <p align="center"><strong>Supported formats</strong><br/>%(formats)s</p>
 <p align="center"><strong>Please donate</strong><br/>
 Thank you for using Picard. Picard relies on the MusicBrainz database, which is operated by the MetaBrainz Foundation with the help of thousands of volunteers. If you like this application please consider donating to the MetaBrainz Foundation to keep the service running.</p>
 <p align="center"><a href="%(picard-donate-url)s">Donate now!</a></p>
 <p align="center"><strong>Credits</strong><br/>
-<small>Copyright © 2004-2014 Robert Kaye, Lukáš Lalinský and others%(translator-credits)s</small></p>
-<p align="center"><a href="%(picard-doc-url)s">%(picard-doc-url)s</a></p>
+<small>Copyright © 2004-2015 Robert Kaye, Lukáš Lalinský, Laurent Monin and others%(translator-credits)s</small></p>
+<p align="center"><strong>Official website</strong><br/><a href="%(picard-doc-url)s">%(picard-doc-url)s</a></p>
 """) % args
         self.ui.label.setOpenExternalLinks(True)
         self.ui.label.setText(text)

--- a/picard/util/versions.py
+++ b/picard/util/versions.py
@@ -18,22 +18,25 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from collections import OrderedDict
 from mutagen import version_string as mutagen_version
-from PyQt4.QtCore import PYQT_VERSION_STR as pyqt_version
+from PyQt4.QtCore import PYQT_VERSION_STR as pyqt_version, QT_VERSION_STR
 from picard import PICARD_FANCY_VERSION_STR
 from picard.disc import discid_version
 
 
-_versions = {
-    "version": PICARD_FANCY_VERSION_STR,
-    "pyqt-version": pyqt_version,
-    "mutagen-version": mutagen_version,
-    "discid-version": discid_version,
-}
+_versions = OrderedDict([
+    ("version", PICARD_FANCY_VERSION_STR),
+    ("pyqt-version", pyqt_version),
+    ("qt-version", QT_VERSION_STR),
+    ("mutagen-version", mutagen_version),
+    ("discid-version", discid_version),
+])
 
 _names = {
     "version": "Picard",
     "pyqt-version": "PyQt",
+    "qt-version": "Qt",
     "mutagen-version": "Mutagen",
     "discid-version": "Discid",
 }
@@ -47,11 +50,17 @@ def _value_as_text(value, i18n=False):
     return value
 
 
+def version_name(key):
+    return _names[key]
+
+
 def as_dict(i18n=False):
-    return dict([(key, _value_as_text(value, i18n)) for key, value in
-                 _versions.iteritems()])
+    return OrderedDict([(key, _value_as_text(value, i18n)) for key,
+                        value in
+                        _versions.items()])
 
 
 def as_string(i18n=False, separator=", "):
+    values = as_dict(i18n)
     return separator.join([_names[key] + " " + value for key, value in
-                           as_dict(i18n).items()])
+                           values.items()])


### PR DESCRIPTION
- keep versions sorted, use OrderedDict
- add -V/--long-version command-line option
- add Qt version in the list of versions
- update About page

Fixes http://tickets.musicbrainz.org/browse/PICARD-734

![capture du 2015-06-29 10 38 02](https://cloud.githubusercontent.com/assets/151042/8404148/0738b9de-1e4b-11e5-881f-acdfa928f1bd.png)
![capture du 2015-06-29 10 37 27](https://cloud.githubusercontent.com/assets/151042/8404149/073f3b10-1e4b-11e5-9ed6-d2332734530b.png)