### PR TITLE
Add an option to fallback on artist's tags

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -83,7 +83,7 @@ class Album(DataObject, Item):
             for file in self.unmatched_files.iterfiles():
                 yield file
 
-    def add_album_artist(self, id):
+    def append_album_artist(self, id):
         album_artist = AlbumArtist(id)
         self._album_artists.append(album_artist)
         return album_artist

--- a/picard/album.py
+++ b/picard/album.py
@@ -84,11 +84,14 @@ class Album(DataObject, Item):
                 yield file
 
     def append_album_artist(self, id):
+        """Append artist id to the list of album artists
+        and return an AlbumArtist instance"""
         album_artist = AlbumArtist(id)
         self._album_artists.append(album_artist)
         return album_artist
 
     def get_album_artists(self):
+        """Returns the list of album artists (as AlbumArtist objects)"""
         return self._album_artists
 
     def _parse_release(self, document):

--- a/picard/album.py
+++ b/picard/album.py
@@ -47,10 +47,8 @@ register_album_metadata_processor(coverart)
 
 
 class AlbumArtist(DataObject):
-    def __init__(self, id, name, sort_name):
+    def __init__(self, id):
         DataObject.__init__(self, id)
-        self.name = name
-        self.sort_name = sort_name
 
 
 class Album(DataObject, Item):
@@ -85,8 +83,8 @@ class Album(DataObject, Item):
             for file in self.unmatched_files.iterfiles():
                 yield file
 
-    def add_album_artist(self, id, name, sort_name):
-        album_artist = AlbumArtist(id, name, sort_name)
+    def add_album_artist(self, id):
+        album_artist = AlbumArtist(id)
         self._album_artists.append(album_artist)
         return album_artist
 

--- a/picard/album.py
+++ b/picard/album.py
@@ -46,6 +46,13 @@ from picard.const import VARIOUS_ARTISTS_ID
 register_album_metadata_processor(coverart)
 
 
+class AlbumArtist(DataObject):
+    def __init__(self, id, name, sort_name):
+        DataObject.__init__(self, id)
+        self.name = name
+        self.sort_name = sort_name
+
+
 class Album(DataObject, Item):
 
     release_group_loaded = QtCore.pyqtSignal()
@@ -65,6 +72,7 @@ class Album(DataObject, Item):
         self.unmatched_files = Cluster(_("Unmatched Files"), special=True, related_album=self, hide_if_empty=True)
         self.errors = []
         self.status = None
+        self._album_artists = []
 
     def __repr__(self):
         return '<Album %s %r>' % (self.id, self.metadata[u"album"])
@@ -76,6 +84,14 @@ class Album(DataObject, Item):
         if not save:
             for file in self.unmatched_files.iterfiles():
                 yield file
+
+    def add_album_artist(self, id, name, sort_name):
+        album_artist = AlbumArtist(id, name, sort_name)
+        self._album_artists.append(album_artist)
+        return album_artist
+
+    def get_album_artists(self):
+        return self._album_artists
 
     def _parse_release(self, document):
         log.debug("Loading release %r ...", self.id)

--- a/picard/mbxml.py
+++ b/picard/mbxml.py
@@ -349,11 +349,7 @@ def release_to_metadata(node, m, album=None):
                     for name_credit in nodes[0].name_credit:
                         if 'artist' in name_credit.children:
                             for artist in name_credit.artist:
-                                albumartist = album.add_album_artist(
-                                    artist.id,
-                                    artist.name[0].text,
-                                    artist.sort_name[0].text
-                                )
+                                albumartist = album.add_album_artist(artist.id)
                                 if 'tag_list' in artist.children:
                                     add_folksonomy_tags(artist.tag_list[0],
                                                         albumartist)

--- a/picard/mbxml.py
+++ b/picard/mbxml.py
@@ -343,6 +343,23 @@ def release_to_metadata(node, m, album=None):
             m['asin'] = nodes[0].text
         elif name == 'artist_credit':
             artist_credit_to_metadata(nodes[0], m, release=True)
+            # set tags from artists
+            if album is not None:
+                if 'name_credit' in nodes[0].children:
+                    for name_credit in nodes[0].name_credit:
+                        if 'artist' in name_credit.children:
+                            for artist in name_credit.artist:
+                                albumartist = album.add_album_artist(
+                                    artist.id,
+                                    artist.name[0].text,
+                                    artist.sort_name[0].text
+                                )
+                                if 'tag_list' in artist.children:
+                                    add_folksonomy_tags(artist.tag_list[0],
+                                                        albumartist)
+                                if 'user_tag_list' in artist.children:
+                                    add_user_folksonomy_tags(artist.user_tag_list[0],
+                                                             albumartist)
         elif name == 'date':
             m['date'] = nodes[0].text
         elif name == 'country':

--- a/picard/mbxml.py
+++ b/picard/mbxml.py
@@ -349,7 +349,7 @@ def release_to_metadata(node, m, album=None):
                     for name_credit in nodes[0].name_credit:
                         if 'artist' in name_credit.children:
                             for artist in name_credit.artist:
-                                albumartist = album.add_album_artist(artist.id)
+                                albumartist = album.append_album_artist(artist.id)
                                 if 'tag_list' in artist.children:
                                     add_folksonomy_tags(artist.tag_list[0],
                                                         albumartist)

--- a/picard/track.py
+++ b/picard/track.py
@@ -162,6 +162,9 @@ class Track(DataObject, Item):
         self.merge_folksonomy_tags(tags, self.album.folksonomy_tags)
         if self.album.release_group:
             self.merge_folksonomy_tags(tags, self.album.release_group.folksonomy_tags)
+        if not tags and config.setting['artists_tags']:
+            for artist in self.album.get_album_artists():
+                self.merge_folksonomy_tags(tags, artist.folksonomy_tags)
         if not tags:
             return
         # Convert counts to values from 0 to 100

--- a/picard/ui/options/folksonomy.py
+++ b/picard/ui/options/folksonomy.py
@@ -36,6 +36,7 @@ class FolksonomyOptionsPage(OptionsPage):
         config.TextOption("setting", "ignore_tags", "seen live,favorites,fixme,owned"),
         config.TextOption("setting", "join_tags", ""),
         config.BoolOption("setting", "only_my_tags", False),
+        config.BoolOption("setting", "artists_tags", False),
     ]
 
     def __init__(self, parent=None):
@@ -49,6 +50,7 @@ class FolksonomyOptionsPage(OptionsPage):
         self.ui.join_tags.setEditText(config.setting["join_tags"])
         self.ui.ignore_tags.setText(config.setting["ignore_tags"])
         self.ui.only_my_tags.setChecked(config.setting["only_my_tags"])
+        self.ui.artists_tags.setChecked(config.setting["artists_tags"])
 
     def save(self):
         config.setting["max_tags"] = self.ui.max_tags.value()
@@ -56,6 +58,7 @@ class FolksonomyOptionsPage(OptionsPage):
         config.setting["join_tags"] = self.ui.join_tags.currentText()
         config.setting["ignore_tags"] = self.ui.ignore_tags.text()
         config.setting["only_my_tags"] = self.ui.only_my_tags.isChecked()
+        config.setting["artists_tags"] = self.ui.artists_tags.isChecked()
 
 
 register_options_page(FolksonomyOptionsPage)

--- a/picard/ui/ui_options_folksonomy.py
+++ b/picard/ui/ui_options_folksonomy.py
@@ -8,12 +8,21 @@ from PyQt4 import QtCore, QtGui
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
 except AttributeError:
-    _fromUtf8 = lambda s: s
+    def _fromUtf8(s):
+        return s
+
+try:
+    _encoding = QtGui.QApplication.UnicodeUTF8
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig, _encoding)
+except AttributeError:
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig)
 
 class Ui_FolksonomyOptionsPage(object):
     def setupUi(self, FolksonomyOptionsPage):
         FolksonomyOptionsPage.setObjectName(_fromUtf8("FolksonomyOptionsPage"))
-        FolksonomyOptionsPage.resize(390, 304)
+        FolksonomyOptionsPage.resize(590, 304)
         self.verticalLayout_2 = QtGui.QVBoxLayout(FolksonomyOptionsPage)
         self.verticalLayout_2.setObjectName(_fromUtf8("verticalLayout_2"))
         self.rename_files_3 = QtGui.QGroupBox(FolksonomyOptionsPage)
@@ -29,6 +38,10 @@ class Ui_FolksonomyOptionsPage(object):
         self.only_my_tags = QtGui.QCheckBox(self.rename_files_3)
         self.only_my_tags.setObjectName(_fromUtf8("only_my_tags"))
         self.verticalLayout.addWidget(self.only_my_tags)
+        self.artists_tags = QtGui.QCheckBox(self.rename_files_3)
+        self.artists_tags.setEnabled(True)
+        self.artists_tags.setObjectName(_fromUtf8("artists_tags"))
+        self.verticalLayout.addWidget(self.artists_tags)
         self.hboxlayout = QtGui.QHBoxLayout()
         self.hboxlayout.setSpacing(6)
         self.hboxlayout.setMargin(0)
@@ -102,6 +115,7 @@ class Ui_FolksonomyOptionsPage(object):
         self.rename_files_3.setTitle(_("Folksonomy Tags"))
         self.ignore_tags_2.setText(_("Ignore tags:"))
         self.only_my_tags.setText(_("Only use my tags"))
+        self.artists_tags.setText(_("Fallback on album\'s artits tags if no tags are found for the release or release group"))
         self.label_5.setText(_("Minimal tag usage:"))
         self.min_tag_usage.setSuffix(_(" %"))
         self.label_6.setText(_("Maximum number of tags:"))

--- a/picard/ui/ui_options_folksonomy.py
+++ b/picard/ui/ui_options_folksonomy.py
@@ -115,7 +115,7 @@ class Ui_FolksonomyOptionsPage(object):
         self.rename_files_3.setTitle(_("Folksonomy Tags"))
         self.ignore_tags_2.setText(_("Ignore tags:"))
         self.only_my_tags.setText(_("Only use my tags"))
-        self.artists_tags.setText(_("Fallback on album\'s artits tags if no tags are found for the release or release group"))
+        self.artists_tags.setText(_("Fallback on album\'s artists tags if no tags are found for the release or release group"))
         self.label_5.setText(_("Minimal tag usage:"))
         self.min_tag_usage.setSuffix(_(" %"))
         self.label_6.setText(_("Maximum number of tags:"))

--- a/picard/ui/ui_options_folksonomy.py
+++ b/picard/ui/ui_options_folksonomy.py
@@ -115,7 +115,7 @@ class Ui_FolksonomyOptionsPage(object):
         self.rename_files_3.setTitle(_("Folksonomy Tags"))
         self.ignore_tags_2.setText(_("Ignore tags:"))
         self.only_my_tags.setText(_("Only use my tags"))
-        self.artists_tags.setText(_("Fallback on album\'s artists tags if no tags are found for the release or release group"))
+        self.artists_tags.setText(_("Fall back on album\'s artists tags if no tags are found for the release or release group"))
         self.label_5.setText(_("Minimal tag usage:"))
         self.min_tag_usage.setSuffix(_(" %"))
         self.label_6.setText(_("Maximum number of tags:"))

--- a/ui/options_folksonomy.ui
+++ b/ui/options_folksonomy.ui
@@ -1,68 +1,79 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>FolksonomyOptionsPage</class>
- <widget class="QWidget" name="FolksonomyOptionsPage" >
-  <property name="geometry" >
+ <widget class="QWidget" name="FolksonomyOptionsPage">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>390</width>
+    <width>590</width>
     <height>304</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2" >
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QGroupBox" name="rename_files_3" >
-     <property name="title" >
+    <widget class="QGroupBox" name="rename_files_3">
+     <property name="title">
       <string>Folksonomy Tags</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout" >
+     <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="QLabel" name="ignore_tags_2" >
-        <property name="text" >
+       <widget class="QLabel" name="ignore_tags_2">
+        <property name="text">
          <string>Ignore tags:</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="ignore_tags" />
+       <widget class="QLineEdit" name="ignore_tags"/>
       </item>
       <item>
-       <widget class="QCheckBox" name="only_my_tags" >
-        <property name="text" >
+       <widget class="QCheckBox" name="only_my_tags">
+        <property name="text">
          <string>Only use my tags</string>
         </property>
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" >
-        <property name="spacing" >
+       <widget class="QCheckBox" name="artists_tags">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Fallback on album's artits tags if no tags are found for the release or release group</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout">
+        <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin" >
+        <property name="margin">
          <number>0</number>
         </property>
         <item>
-         <widget class="QLabel" name="label_5" >
-          <property name="sizePolicy" >
-           <sizepolicy vsizetype="Preferred" hsizetype="Expanding" >
+         <widget class="QLabel" name="label_5">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="text" >
+          <property name="text">
            <string>Minimal tag usage:</string>
           </property>
-          <property name="buddy" >
+          <property name="buddy">
            <cstring>min_tag_usage</cstring>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QSpinBox" name="min_tag_usage" >
-          <property name="suffix" >
+         <widget class="QSpinBox" name="min_tag_usage">
+          <property name="suffix">
            <string> %</string>
           </property>
-          <property name="maximum" >
+          <property name="maximum">
            <number>100</number>
           </property>
          </widget>
@@ -70,32 +81,32 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" >
-        <property name="spacing" >
+       <layout class="QHBoxLayout">
+        <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin" >
+        <property name="margin">
          <number>0</number>
         </property>
         <item>
-         <widget class="QLabel" name="label_6" >
-          <property name="sizePolicy" >
-           <sizepolicy vsizetype="Preferred" hsizetype="Expanding" >
+         <widget class="QLabel" name="label_6">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="text" >
+          <property name="text">
            <string>Maximum number of tags:</string>
           </property>
-          <property name="buddy" >
+          <property name="buddy">
            <cstring>min_tag_usage</cstring>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QSpinBox" name="max_tags" >
-          <property name="maximum" >
+         <widget class="QSpinBox" name="max_tags">
+          <property name="maximum">
            <number>100</number>
           </property>
          </widget>
@@ -103,49 +114,49 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" >
-        <property name="spacing" >
+       <layout class="QHBoxLayout">
+        <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin" >
+        <property name="margin">
          <number>0</number>
         </property>
         <item>
-         <widget class="QLabel" name="ignore_tags_4" >
-          <property name="sizePolicy" >
-           <sizepolicy vsizetype="Preferred" hsizetype="Preferred" >
+         <widget class="QLabel" name="ignore_tags_4">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>4</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="text" >
+          <property name="text">
            <string>Join multiple tags with:</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="join_tags" >
-          <property name="sizePolicy" >
-           <sizepolicy vsizetype="Fixed" hsizetype="Preferred" >
+         <widget class="QComboBox" name="join_tags">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>1</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="editable" >
+          <property name="editable">
            <bool>true</bool>
           </property>
           <item>
-           <property name="text" >
+           <property name="text">
             <string/>
            </property>
           </item>
           <item>
-           <property name="text" >
+           <property name="text">
             <string> / </string>
            </property>
           </item>
           <item>
-           <property name="text" >
+           <property name="text">
             <string>, </string>
            </property>
           </item>
@@ -158,10 +169,10 @@
    </item>
    <item>
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" stdset="0" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>181</width>
        <height>31</height>

--- a/ui/options_folksonomy.ui
+++ b/ui/options_folksonomy.ui
@@ -40,7 +40,7 @@
          <bool>true</bool>
         </property>
         <property name="text">
-         <string>Fallback on album's artists tags if no tags are found for the release or release group</string>
+         <string>Fall back on album's artists tags if no tags are found for the release or release group</string>
         </property>
        </widget>
       </item>

--- a/ui/options_folksonomy.ui
+++ b/ui/options_folksonomy.ui
@@ -40,7 +40,7 @@
          <bool>true</bool>
         </property>
         <property name="text">
-         <string>Fallback on album's artits tags if no tags are found for the release or release group</string>
+         <string>Fallback on album's artists tags if no tags are found for the release or release group</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
When the option is disabled, if no tags are found for release / release group, no genre is set.
With this option is checked, Picard will try to use album's artists tags in this case.

![capture du 2015-07-05 11 36 12](https://cloud.githubusercontent.com/assets/151042/8511122/1ae4b776-230a-11e5-80a2-724701f898f6.png)


Ie. for release
http://musicbrainz.org/release/ec102c8e-981b-4aec-b1e4-35eda11f2bb6 it will set Genre to "Doom metal" even though there are no tags for release or release group.

![capture du 2015-07-05 11 28 36](https://cloud.githubusercontent.com/assets/151042/8511121/f9facc08-2309-11e5-852b-7987db2402f5.png)

http://tickets.musicbrainz.org/browse/PICARD-738