### PR TITLE
PICARD-753: ignore downvoted tags

### DIFF
--- a/picard/track.py
+++ b/picard/track.py
@@ -165,6 +165,8 @@ class Track(DataObject, Item):
         if not tags and config.setting['artists_tags']:
             for artist in self.album.get_album_artists():
                 self.merge_folksonomy_tags(tags, artist.folksonomy_tags)
+        # Ignore tags with zero or lower score
+        tags = dict((name, count) for name, count in tags.items() if count > 0)
         if not tags:
             return
         # Convert counts to values from 0 to 100


### PR DESCRIPTION
When all tags have 0 votes, maxcount is 0, leading to a division by zero exception.

So filter the tags dict to only keep tags having positive votes count.