### PR TITLE
Ignore zero count tags

### DIFF
--- a/picard/track.py
+++ b/picard/track.py
@@ -171,9 +171,12 @@ class Track(DataObject, Item):
             return
         # Convert counts to values from 0 to 100
         maxcount = max(tags.values())
+        if maxcount == 0:
+            return
         taglist = []
         for name, count in tags.items():
-            taglist.append((100 * count / maxcount, name))
+            if count > 0:
+                taglist.append((100 * count / maxcount, name))
         taglist.sort(reverse=True)
         # And generate the genre metadata tag
         maxtags = config.setting['max_tags']


### PR DESCRIPTION
Fixes division by zero exception reported in [PICARD-759](http://tickets.musicbrainz.org/browse/PICARD-759)

This is consistent with the server UI which also doesn't show zero count tags by default.