### PR TITLE
Fix for Gnome 3 Alt-Tab application name and window grouping.

### DIFF
--- a/picard.desktop
+++ b/picard.desktop
@@ -5,6 +5,7 @@ Exec=picard %F
 Terminal=false
 Type=Application
 StartupNotify=true
+StartupWMClass=MusicBrainz-Picard
 Icon=picard
 Categories=AudioVideo;Audio;AudioVideoEditing;
 MimeType=audio/x-mp3;audio/ogg;audio/mpeg;application/ogg;audio/x-flac;audio/x-flac+ogg;audio/x-vorbis+ogg;audio/x-speex+ogg;audio/x-oggflac;audio/x-musepack;audio/x-tta;audio/x-ms-wma;audio/x-wavpack;

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -96,7 +96,9 @@ class Tagger(QtGui.QApplication):
     __instance = None
 
     def __init__(self, args, localedir, autoupdate, debug=False):
-        QtGui.QApplication.__init__(self, args)
+        # Set the WM_CLASS to 'MusicBrainz-Picard' so desktop environments
+        # can use it to look up the app
+        QtGui.QApplication.__init__(self, ['MusicBrainz-Picard'] + args)
         self.__class__.__instance = self
 
         self._args = args


### PR DESCRIPTION
Fixes [PICARD-761](http://tickets.musicbrainz.org/browse/PICARD-761)

Gnome Shell currently fails to determine that a running Picard window belongs to the Picard application (meaning an application that has a .desktop file and is available in the application menu). That has some bad effects on both the Alt-Tab switcher and also the dock (see PICARD-761). Gnome applies various strategies to get the app from a running window, see https://git.gnome.org/browse/gnome-shell/tree/src/shell-window-tracker.c?h=gnome-3-16#n329 . Currently all approaches fail, as a result Gnome treats every Picard window as an application-less window.

This patch sets a unique WM_CLASS for Picard which Gnome can use to match it to the .desktop file.

Without this patch:

![Picard in Gnome, no grouping](http://tickets.musicbrainz.org/secure/attachment/11082/picard-gnome3-alttab.png)

With patch:

![Picard in Gnome, fixed grouping](http://tickets.musicbrainz.org/secure/attachment/11083/picard-gnome3-alttab-with-patch.png)

I am not entirely sure why this is necessary, AFAIK this should be handled by the StartupNotification, too. But I could not figure out how to debug that. The fix applied works and might also work for other desktop environments, which could have similar issues.