### PR TITLE
PICARD 780: CAA cover art provider runs even if cover art has already been loaded

### DIFF
--- a/picard/coverart/providers/__init__.py
+++ b/picard/coverart/providers/__init__.py
@@ -134,8 +134,8 @@ class CoverArtProvider(object):
         # CoverArtProvider.WAIT
         old = getattr(self, 'queue_downloads') #compat with old plugins
         if callable(old):
-            old()
             log.warning('CoverArtProvider: queue_downloads() was replaced by queue_images()')
+            return old()
         else:
             raise NotImplementedError
 

--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -246,7 +246,8 @@ class CoverArtProviderCaa(CoverArtProvider):
 
     def enabled(self):
         """Check if CAA artwork has to be downloaded"""
-        if not super(CoverArtProviderCaa, self).enabled():
+        if not super(CoverArtProviderCaa, self).enabled() or \
+                self.coverart.front_image_found:
             return False
         if self.restrict_types and not self.len_caa_types:
             log.debug("User disabled all Cover Art Archive types")


### PR DESCRIPTION
I wonder why **old** was not returned in the first place. Without it, *next_in_queue* was unable to check for *WAIT* signal, as None was returned.

http://tickets.musicbrainz.org/browse/PICARD-780