### PR TITLE
Increase default width of option dialog

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -49,7 +49,7 @@ class OptionsDialog(PicardDialog):
 
     options = [
         config.Option("persist", "options_position", QtCore.QPoint()),
-        config.Option("persist", "options_size", QtCore.QSize(560, 400)),
+        config.Option("persist", "options_size", QtCore.QSize(700, 400)),
         config.Option("persist", "options_splitter", QtCore.QByteArray()),
     ]
 


### PR DESCRIPTION
If one runs Picard for the first time (or restarts after removing Picard.conf), most text in the option dialog is hidden. Here is a screenshot of that:

Running Picard for first time:
![picard_text_omitted](https://cloud.githubusercontent.com/assets/7776696/12220543/c35951d4-b79b-11e5-8445-fe5d253aecf2.png)

IMHO, it should look like this:
![picard_option_dialog_expanded](https://cloud.githubusercontent.com/assets/7776696/12220549/0006550a-b79c-11e5-9ccd-f263a70f1453.png)

I've checked this on Arch, and Kubuntu, on a 1366*768 display.