### PR TITLE
Fix relative redirects

### DIFF
--- a/picard/webservice.py
+++ b/picard/webservice.py
@@ -263,34 +263,38 @@ class XmlWebService(QtCore.QObject):
                       )
             if handler is not None:
                 # Redirect if found and not infinite
-                if redirect and not XmlWebService.urls_equivalent(redirect, reply.request().url()):
-                    log.debug("Redirect to %s requested", redirect.toString(QUrl.RemoveUserInfo))
-                    redirect_host = str(redirect.host())
-                    redirect_port = redirect.port(80)
-
+                if redirect:
                     url = request.url()
-                    original_host = str(url.host())
-                    original_port = url.port(80)
+                    # merge with base url (to cover the possibility of the URL being relative)
+                    redirect = url.resolved(redirect)
+                    if not XmlWebService.urls_equivalent(redirect, reply.request().url()):
+                        log.debug("Redirect to %s requested", redirect.toString(QUrl.RemoveUserInfo))
+                        redirect_host = str(redirect.host())
+                        redirect_port = redirect.port(80)
+                        redirect_query = dict(redirect.queryItems())
+                        redirect_path = redirect.path()
 
-                    if ((original_host, original_port) in REQUEST_DELAY
-                            and (redirect_host, redirect_port) not in REQUEST_DELAY):
-                        log.debug("Setting rate limit for %s:%i to %i" %
-                                  (redirect_host, redirect_port,
-                                   REQUEST_DELAY[(original_host, original_port)]))
-                        REQUEST_DELAY[(redirect_host, redirect_port)] =\
-                            REQUEST_DELAY[(original_host, original_port)]
+                        original_host = str(url.host())
+                        original_port = url.port(80)
 
-                    self.get(redirect_host,
-                             redirect_port,
-                             # retain path, query string and anchors from redirect URL
-                             redirect.toString(QUrl.RemoveAuthority | QUrl.RemoveScheme),
-                             handler, xml, priority=True, important=True, refresh=refresh,
-                             cacheloadcontrol=request.attribute(QtNetwork.QNetworkRequest.CacheLoadControlAttribute))
-                elif redirect:
-                    log.error("Redirect loop: %s",
-                              reply.request().url().toString(QUrl.RemoveUserInfo)
-                              )
-                    handler(str(reply.readAll()), reply, error)
+                        if ((original_host, original_port) in REQUEST_DELAY
+                                and (redirect_host, redirect_port) not in REQUEST_DELAY):
+                            log.debug("Setting rate limit for %s:%i to %i" %
+                                      (redirect_host, redirect_port,
+                                       REQUEST_DELAY[(original_host, original_port)]))
+                            REQUEST_DELAY[(redirect_host, redirect_port)] =\
+                                REQUEST_DELAY[(original_host, original_port)]
+
+                        self.get(redirect_host,
+                                 redirect_port,
+                                 redirect_path,
+                                 handler, xml, priority=True, important=True, refresh=refresh, queryargs=redirect_query,
+                                 cacheloadcontrol=request.attribute(QtNetwork.QNetworkRequest.CacheLoadControlAttribute))
+                    else:
+                        log.error("Redirect loop: %s",
+                                  reply.request().url().toString(QUrl.RemoveUserInfo)
+                                  )
+                        handler(str(reply.readAll()), reply, error)
                 elif xml:
                     document = _read_xml(QXmlStreamReader(reply))
                     handler(document, reply, error)


### PR DESCRIPTION
#### Fixes relative redirects
as reported in http://tickets.musicbrainz.org/browse/PICARD-788

Implements [the recommendation in the Qt documentation regarding QNetworkRequest.RedirectionTargetAttribute](http://pyqt.sourceforge.net/Docs/PyQt4/qnetworkrequest.html):
>The returned URL might be relative. Use QUrl.resolved() to create an absolute URL out of it.

Also fixes a issue where during redirects query arguments would be treated as part of the path and thus percent-encoded, by using `redirect.path()` and `redirect.queryItems()`, instead of directly using the path in the new request.

#### Logs

##### Before:
>D: 20:40:08 Waiting 510 ms before starting another request to ('anidb.net', 80)
>D: 20:40:08 Last request to ('anidb.net', 80) was 2515 ms ago, starting another one
>D: 20:40:08 GET http://anidb.net/perl-bin/animedb.pl?adb.search=%E3%83%88%E3%82%A5%E3%83%83%E3%83%86%E3%82%A3%21&show=songlist&do.search=search
>D: 20:40:09 Received reply for http://anidb.net/perl-bin/animedb.pl?adb.search=トゥッティ!&show=songlist&do.search=search: HTTP 302 (Found) 
>D: 20:40:09 Redirect to animedb.pl?show=song&songid=80421 requested
>D: 20:40:09 Setting rate limit for :80 to 2500
>D: 20:40:09 Last request to ('', 80) was 2500 ms ago, starting another one
>D: 20:40:09 GET http://animedb.pl?show=song&songid=80421
>E: 20:40:09 Network request error for http://animedb.pl?show=song&songid=80421: Host animedb.pl not found (QT code 3, HTTP code None)

##### After:
>D: 23:21:48 WSREQ: Last request to ('anidb.net', 80) was 2500 ms ago, starting another one
>D: 23:21:49 Received reply for http://anidb.net:80/perl-bin/animedb.pl?do.search=search&adb.search=トゥッティ!&show=songlist: HTTP 302 (Found) 
>D: 23:21:49 Redirect to http://anidb.net:80/perl-bin/animedb.pl?show=song&songid=80421 requested
>D: 23:21:51 WSREQ: Last request to ('anidb.net', 80) was 2500 ms ago, starting another one
>D: 23:21:51 Received reply for http://anidb.net:80/perl-bin/animedb.pl?songid=80421&show=song: HTTP 200 (OK)