### PR TITLE
Fall back to track artist tags for genre on comps.

### DIFF
--- a/picard/mbxml.py
+++ b/picard/mbxml.py
@@ -281,6 +281,17 @@ def recording_to_metadata(node, track):
             m['~recordingcomment'] = nodes[0].text
         elif name == 'artist_credit':
             artist_credit_to_metadata(nodes[0], m)
+            if 'name_credit' in nodes[0].children:
+                for name_credit in nodes[0].name_credit:
+                    if 'artist' in name_credit.children:
+                        for artist in name_credit.artist:
+                            trackartist = track.append_track_artist(artist.id)
+                            if 'tag_list' in artist.children:
+                                add_folksonomy_tags(artist.tag_list[0],
+                                                    trackartist)
+                            if 'user_tag_list' in artist.children:
+                                add_user_folksonomy_tags(artist.user_tag_list[0],
+                                                         trackartist)
         elif name == 'relation_list':
             _relations_to_metadata(nodes, m)
         elif name == 'tag_list':


### PR DESCRIPTION
Commit 334eba9d2823ac9d73f09b087643f6a4df745aaf added support for
falling back to the album artist's folksonomy tags for releases/release
groups without tags. This change adds further support to that to allow
compilation releases to use the track artists' tags since album artist
won't work.